### PR TITLE
Force files existing on a target location to be removed when deploying with fileExistsBehavior as "OVERWRITE"

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/install_instruction.rb
+++ b/lib/instance_agent/plugins/codedeploy/install_instruction.rb
@@ -232,7 +232,7 @@ module InstanceAgent
           # the CopyCommand entry should not even be created by Installer
           cleanup_file.puts(@destination)
           if File.symlink?(@source)
-            FileUtils.symlink(File.readlink(@source), @destination)
+            FileUtils.symlink(File.readlink(@source), @destination, :force => true)
           else
             FileUtils.copy(@source, @destination, :preserve => true)
           end

--- a/lib/instance_agent/plugins/codedeploy/installer.rb
+++ b/lib/instance_agent/plugins/codedeploy/installer.rb
@@ -123,6 +123,9 @@ module InstanceAgent
             when "DISALLOW"
               raise "The deployment failed because a specified file already exists at this location: #{destination}"
             when "OVERWRITE"
+              if File.directory?(destination)
+                raise "The deployment failed because a directory already exists at this location: #{destination}"
+              end
               i.copy(absolute_source_path, destination)
             when "RETAIN"
               # neither generate copy command or fail the deployment


### PR DESCRIPTION
### Issue #143:
#### Summary
Fixed an error that caused the OVERWRITE option to behave abnormally if the source file is a symlink and the file already exists in the destination path. ( raise ``Errno::EEXIST Exception`` )

### Description of changes:
This PR makes the installer deletes the destination files before copying the files If using the OVERWIRTE option.

#### Reason
1. If a file already exists, the installer should not call the CopyCommand class.
    * So I changed the call to CopyCommand only if there were no files.
2. If the Destination file is a directory, must prevent the file from being copied to the sub-directory.
    * ```Errno::EEXIST Exception``` can be avoided by adding the ``force=> true`` option to ``FileUtils.symlink``. ( in ``CopyCommand.execution()`` function )
    * However, if the Destination file is a directory, the symlink file is copied below the directory (the problem is also occurring with ``FileUtils.copy``). 

#### issue error log sample
```
2019-01-05 10:29:24 ERROR [codedeploy-agent(16431)]: InstanceAgent::Plugins::CodeDeployPlugin::CommandPoller: Error during perform: Errno::EEXIST - File exists @ syserr_fail2_in - /tmp/apps/app/sym-folder/apps - /usr/lib/ruby/2.3.0/fileutils.rb:358:in `symlink'
/usr/lib/ruby/2.3.0/fileutils.rb:358:in `block in ln_s'
/usr/lib/ruby/2.3.0/fileutils.rb:1585:in `fu_each_src_dest0'
/usr/lib/ruby/2.3.0/fileutils.rb:356:in `ln_s'
```


--- 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
