### PR TITLE
Ignore non-empty directories in cleanup file

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/install_instruction.rb
+++ b/lib/instance_agent/plugins/codedeploy/install_instruction.rb
@@ -209,10 +209,10 @@ module InstanceAgent
             FileUtils.rm(@file_path)
           elsif File.exist?(@file_path)
             if File.directory?(@file_path)
-              # TODO (AWSGLUE-713): handle the exception if the directory is non-empty;
-              # this might mean the customer has put files in this directory and we should
-              # probably ignore the error and move on
-              FileUtils.rmdir(@file_path)
+              begin
+                FileUtils.rmdir(@file_path)
+              rescue Errno::ENOTEMPTY
+              end
             else
               FileUtils.rm(@file_path)
             end

--- a/test/instance_agent/plugins/codedeploy/install_instruction_test.rb
+++ b/test/instance_agent/plugins/codedeploy/install_instruction_test.rb
@@ -232,18 +232,18 @@ module InstanceAgent
           context "an empty delete file" do
             setup do
               @parse_string = <<-END
-            END
+              END
+            end
+
+            should "return an empty command collection" do
+              commands = InstallInstruction.parse_remove_commands(@parse_string)
+              assert_equal 0, commands.length
+            end
           end
 
-          should "return an empty command collection" do
-            commands = InstallInstruction.parse_remove_commands(@parse_string)
-            assert_equal 0, commands.length
-          end
-        end
-
-        context "a single file to delete" do
-          setup do
-            @parse_string = <<-END
+          context "a single file to delete" do
+            setup do
+              @parse_string = <<-END
             test_delete_path
               END
               File.stubs(:exist?).with("test_delete_path").returns(true)

--- a/test/instance_agent/plugins/codedeploy/install_instruction_test.rb
+++ b/test/instance_agent/plugins/codedeploy/install_instruction_test.rb
@@ -231,8 +231,7 @@ module InstanceAgent
         context "Parsing a delete file" do
           context "an empty delete file" do
             setup do
-              @parse_string = <<-END
-              END
+              @parse_string = ""
             end
 
             should "return an empty command collection" do
@@ -243,9 +242,7 @@ module InstanceAgent
 
           context "a single file to delete" do
             setup do
-              @parse_string = <<-END
-            test_delete_path
-              END
+              @parse_string = "test_delete_path\n"
               File.stubs(:exist?).with("test_delete_path").returns(true)
             end
 
@@ -281,10 +278,7 @@ module InstanceAgent
 
           context "multiple files to delete" do
             setup do
-              @parse_string = <<-END
-            test_delete_path
-            another_delete_path
-              END
+              @parse_string = "test_delete_path\nanother_delete_path\n"
               File.stubs(:directory?).returns(false)
               File.stubs(:exist?).with("test_delete_path").returns(true)
               File.stubs(:exist?).with("another_delete_path").returns(true)
@@ -315,11 +309,7 @@ module InstanceAgent
 
           context "removes mangled line at the end" do
             setup do
-              @parse_string = <<-END
-            test_delete_path
-            another_delete_path
-              END
-              @parse_string << "mangled"
+              @parse_string = "test_delete_path\nanother_delete_path\nmangled"
               File.stubs(:exist?).with("test_delete_path").returns(true)
               File.stubs(:exist?).with("another_delete_path").returns(true)
             end
@@ -338,7 +328,7 @@ module InstanceAgent
 
           context "correctly determines method from file type" do
             setup do
-              @parse_string = 'foo'
+              @parse_string = "foo\n"
               @instruction_file = mock
               @instruction_file.stubs(:path).returns("test/123-cleanup")
               File.stubs(:open).with("test/123-cleanup", 'r').returns(@instruction_file)


### PR DESCRIPTION
This closes aws#185.

### Description of changes
When installing ruby in `ubuntu 18.04`, ruby version `2.5.x` is installed by default.

Before ruby `2.5`(i.e., `2.4.3`), `FileUtils.rmdir` [silently fails when the target directory is not empty](https://ruby-doc.org/stdlib-2.4.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-rmdir), so the non-empty directories in cleanup file are not removed. 

But the implementation of `FileUtils.rmdir` is [changed in ruby `2.5`](https://ruby-doc.org/stdlib-2.5.0/libdoc/fileutils/rdoc/FileUtils.html#method-c-rmdir) so that it doesn’t rescue from `Errno::ENOTEMPTY` any more, which generates failures in deployment.

This PR adds a rescue from `Errno::ENOTEMPTY`, thus non-empty directories in cleanup file are not removed for ruby 2.5 and forward, and the deployment does not fail.

---

Note: There are two other exceptions(`Errno::EEXIST`, `Errno::ENOENT`) that have been rescued before ruby `2.5`. We don't rescue them because:
- `Errno::EEXIST` - [File exists](http://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html): it doesn't occur in our use case. (Frankly I have no idea why this rescue is needed from the first time)
- `Errno::ENOENT` - [No such file or directory](http://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html): it doesn't occur since we first check `File.exist?(@file_path)` before `FileUtils.rmdir(@file_path)` is executed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.