### PR TITLE
add local gems to $LOAD_PATH

### DIFF
--- a/lib/codedeploy-agent.rb
+++ b/lib/codedeploy-agent.rb
@@ -15,6 +15,7 @@ end
 # if installed as a gem
 
 agent_dir = "/opt/codedeploy-agent"
+$:.unshift *Dir.glob("#{agent_dir}/vendor/gems/**/lib")
 $:.unshift "#{agent_dir}/lib"
 # Required for integration tests to run correctly
 $:.unshift File.join(File.dirname(File.expand_path('..', __FILE__)), 'lib')


### PR DESCRIPTION
*Issue #133, if available:*

### 문제 현상
aws-sdk-core의 최신 버전이 인스턴스에 설치되어 있는 경우, 과거에 [deprecated](https://github.com/aws/aws-sdk-ruby/commit/f620737c90ce647dad76ba88c6ae4c1604ad6542#diff-513518e0586b1edf09135c3dfe1fb337) 된 Seahorse::Util::Module 의 underscore 메서드를 호출하는 과정에서 undefined method 에러가 발생이 되서 생긴 문제이다.

### 문제 원인
에이전트가 사용하는 gem을 로드할 때 인스턴스에 설치된 최신 버전의 gem 을 로드하기 때문에 발생되는 문제이다.

### 해결 방법
에이전트가 gem을 로드할 때 최신 버전이 아닌 에이전트가 설치된 경로안에 있는 gem을 우선적으로 로드하도록 해줘야 한다

### Description of changes:
$LOAD_PATH 에 vendor 하위에 있는 gem 들의 경로를 추가하도록 하였다.

주의할 점은 `$:.unshift "#{agent_dir}/lib"` 이전에 실행함으로써 "/opt/codedeploy-agent/lib" 가 맨처음에 위치하도록 해야 한다. 왜냐하면 vendor 하위에도 core_ext.rb 라는 파일이 있기 때문에 순서가 바뀌면 문제가 발생한다.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
